### PR TITLE
8 axes take 2

### DIFF
--- a/forestplot.js
+++ b/forestplot.js
@@ -206,7 +206,10 @@ function forestplot(data, element, groups, pairs){
             .attr('stroke-opacity', 0.3);
 
 
-
+        let group_number = chart.groups.length/15;
+        console.log(group_number)
+        let group_width = chart.groups.map(x => ({width: `${group_number}%`}));
+        console.log(group_width)
         let table = $('.forestplot table').DataTable({ 
             "dom": '<"top"if>rt<"clear">',
             "paging": false, 
@@ -214,9 +217,7 @@ function forestplot(data, element, groups, pairs){
             "columns": [
                 { "width": "2%" },
                 { "width": "2%" },
-                { "width": "5%" },
-                { "width": "5%" },
-                { "width": "5%" },
+                group_width,
                 { "width": "25%" },
                 { "width": "5%" },
                 { "width": "5%" },

--- a/forestplot.js
+++ b/forestplot.js
@@ -42,7 +42,7 @@ function forestplot(data, element, groups, pairs){
 
     let all_ors = d3.merge(data.map(m => m.pairs.map(n => n.or)))
     let or_extent = d3.extent(all_ors)
-    let orScale = d3.scale.linear().range([10, 110]).domain(or_extent)
+    let orScale = d3.scale.linear().range([10, 290]).domain(or_extent)
     
     //header   
     chart.draw = function(data,groups,pairs){
@@ -113,7 +113,7 @@ function forestplot(data, element, groups, pairs){
         
 
         //group plot
-        chart.groupPlot = chart.rows.append("td","group-plot").append("svg").attr("height",20).attr("width","100%")
+        chart.groupPlot = chart.rows.append("td","group-plot").append("svg").attr("height",20).attr("width",120)
         chart.groupPlot.selectAll("circle")
         .data(d=>d.groups)
         .enter()
@@ -145,7 +145,7 @@ function forestplot(data, element, groups, pairs){
             .attr('class','diffplot')
             .append('svg')
             .attr('height', 20)
-            .attr('width', "100%")
+            .attr('width', 300)
             .append('g')
 
         

--- a/forestplot.js
+++ b/forestplot.js
@@ -42,8 +42,9 @@ function forestplot(data, element, groups, pairs){
 
     let all_ors = d3.merge(data.map(m => m.pairs.map(n => n.or)))
     let or_extent = d3.extent(all_ors)
-    let orScale = d3.scale.linear().range([10, 290]).domain(or_extent)
-    
+    let orScale = d3.scale.linear().range([10, 290]).domain([0,or_extent[1]])
+
+
     //header   
     chart.draw = function(data,groups,pairs){
         chart.table.selectAll("*").remove()
@@ -58,11 +59,9 @@ function forestplot(data, element, groups, pairs){
         chart.head2.append("th").text("System Organ Class")
         chart.head2.append("th").text("Preferred Term")
         chart.head2.selectAll("th.group").data(groups).enter().append("th").text(d=>d)
-        chart.head2.append("th").html('Rates').attr("class", "rates")
-        
+
         var groupAxis = d3.svg.axis().scale(groupScale).ticks(6).orient("top");
-        chart.head2.select(".rates")
-            .attr("class","axis")
+        chart.head2.append("th").text("Rates").attr("class", "rates axis")
             .append('svg')
             .attr('height', 20)
             .attr('width', 120)
@@ -74,10 +73,7 @@ function forestplot(data, element, groups, pairs){
         chart.head2.selectAll("th.pairs").data(pairs).enter().append("th").text(d => d[0]+" vs."+d[1])
         var orAxis = d3.svg.axis().scale(orScale).ticks(6).orient("top");
 
-        chart.head2.append("th").html('Diffs').attr("class", "diffs");
-        
-        chart.head2.select(".diffs")
-            .attr("class","axis")
+        chart.head2.append("th").text("Comparison").attr("class", "diffs axis")
             .append('svg')
             .attr('height', '20')
             .attr('width', 300)
@@ -110,7 +106,7 @@ function forestplot(data, element, groups, pairs){
         
 
         //group plot
-        chart.groupPlot = chart.rows.append("td","group-plot").append("svg").attr("height",20).attr("width",120)
+        chart.groupPlot = chart.rows.append("td").attr("class","group-plot plot").append("svg").attr("height",20).attr("width",120)
         chart.groupPlot.selectAll("circle")
         .data(d=>d.groups)
         .enter()
@@ -139,13 +135,11 @@ function forestplot(data, element, groups, pairs){
         
 
         var diffPlots = chart.rows.append("td")
-            .attr('class','diffplot')
+            .attr('class','diffplot plot')
             .append('svg')
             .attr('height', 20)
             .attr('width', 300)
             .append('g')
-
-        
 
         var diffPoints = diffPlots.selectAll('g').data(d=>d.pairs.filter(f=>f.or)).enter().append('g');
         diffPoints.append('title').text(d=>d.label+": "+d.or+" (p="+d.p+")");
@@ -208,9 +202,9 @@ function forestplot(data, element, groups, pairs){
             "paging": false, 
             "order": [[2, "desc"]],
             "columnDefs": [
-                { "width": "120px", "targets":  3 + chart.groups.length},
-                { "width": "300px", "targets":  3 + chart.groups.length + chart.pairs.length}
-              ]
+                { "width": "120px", "targets":  2 + chart.groups.length},
+                { "width": "300px", "targets":  2 + chart.groups.length + 1 + chart.pairs.length}
+            ]
         }).columns.adjust().draw();
 
         // make controls

--- a/forestplot.js
+++ b/forestplot.js
@@ -58,36 +58,33 @@ function forestplot(data, element, groups, pairs){
         chart.head2.append("th").text("System Organ Class")
         chart.head2.append("th").text("Preferred Term")
         chart.head2.selectAll("th.group").data(groups).enter().append("th").text(d=>d)
-        chart.head2.append("th").html('Rates <br><small>['+percent_extent[0]+", "+percent_extent[1]+"]</small>")
-        /*
-        var groupAxis = d3.svg.axis().scale(groupScale).ticks(6).orient("top").;
-        chart.head2.append("th")
+        chart.head2.append("th").html('Rates').attr("class", "rates")
+        
+        var groupAxis = d3.svg.axis().scale(groupScale).ticks(6).orient("top");
+        chart.head2.select(".rates")
             .attr("class","axis")
             .append('svg')
             .attr('height', 20)
             .attr('width', 120)
             .append('svg:g')
             .attr('class', 'axis percent')
-            .attr("transform", "translate(0,20)")
+            .attr("transform", "translate(0,22)")
             .call(groupAxis)
-        */  
 
         chart.head2.selectAll("th.pairs").data(pairs).enter().append("th").text(d => d[0]+" vs."+d[1])
         var orAxis = d3.svg.axis().scale(orScale).ticks(6).orient("top");
 
-        chart.head2.append("th").html('Diffs <br><small>['+or_extent[0]+", "+or_extent[1]+"]</small>")
-
-        /*
-        chart.head2.append("th")
+        chart.head2.append("th").html('Diffs').attr("class", "diffs");
+        
+        chart.head2.select(".diffs")
             .attr("class","axis")
             .append('svg')
             .attr('height', '20')
-            .attr('width', 100)
+            .attr('width', 300)
             .append('svg:g')
             .attr('class', 'axis percent')
             .attr("transform", "translate(0,20)")
             .call(orAxis);
-        */
 
         chart.body = chart.table.append("tbody")
         chart.rows = chart.body.selectAll("tr").data(data).enter().append("tr")

--- a/forestplot.js
+++ b/forestplot.js
@@ -68,7 +68,7 @@ function forestplot(data, element, groups, pairs){
             .attr('width', 120)
             .append('svg:g')
             .attr('class', 'axis percent')
-            .attr("transform", "translate(0,22)")
+            .attr("transform", "translate(0,20)")
             .call(groupAxis)
 
         chart.head2.selectAll("th.pairs").data(pairs).enter().append("th").text(d => d[0]+" vs."+d[1])

--- a/forestplot.js
+++ b/forestplot.js
@@ -113,7 +113,7 @@ function forestplot(data, element, groups, pairs){
         
 
         //group plot
-        chart.groupPlot = chart.rows.append("td","group-plot").append("svg").attr("height",20).attr("width",120)
+        chart.groupPlot = chart.rows.append("td","group-plot").append("svg").attr("height",20).attr("width","100%")
         chart.groupPlot.selectAll("circle")
         .data(d=>d.groups)
         .enter()
@@ -145,7 +145,7 @@ function forestplot(data, element, groups, pairs){
             .attr('class','diffplot')
             .append('svg')
             .attr('height', 20)
-            .attr('width', 120)
+            .attr('width', "100%")
             .append('g')
 
         
@@ -212,15 +212,15 @@ function forestplot(data, element, groups, pairs){
             "paging": false, 
             "order": [[2, "desc"]],
             "columns": [
+                { "width": "2%" },
+                { "width": "2%" },
                 { "width": "5%" },
                 { "width": "5%" },
                 { "width": "5%" },
+                { "width": "25%" },
                 { "width": "5%" },
                 { "width": "5%" },
-                { "width": "5%" },
-                { "width": "5%" },
-                { "width": "5%" },
-                { "width": "60%" },
+                { "width": "46%" },
               ]
         }).columns.adjust().draw();
 

--- a/forestplot.js
+++ b/forestplot.js
@@ -206,22 +206,13 @@ function forestplot(data, element, groups, pairs){
             .attr('stroke-opacity', 0.3);
 
 
-        let group_number = chart.groups.length/15;
-        console.log(group_number)
-        let group_width = chart.groups.map(x => ({width: `${group_number}%`}));
-        console.log(group_width)
         let table = $('.forestplot table').DataTable({ 
             "dom": '<"top"if>rt<"clear">',
             "paging": false, 
             "order": [[2, "desc"]],
-            "columns": [
-                { "width": "2%" },
-                { "width": "2%" },
-                group_width,
-                { "width": "25%" },
-                { "width": "5%" },
-                { "width": "5%" },
-                { "width": "46%" },
+            "columnDefs": [
+                { "width": "120px", "targets":  3 + chart.groups.length},
+                { "width": "300px", "targets":  3 + chart.groups.length + chart.pairs.length}
               ]
         }).columns.adjust().draw();
 

--- a/forestplot.js
+++ b/forestplot.js
@@ -210,8 +210,19 @@ function forestplot(data, element, groups, pairs){
         let table = $('.forestplot table').DataTable({ 
             "dom": '<"top"if>rt<"clear">',
             "paging": false, 
-            "order": [[2, "desc"]]
-        });
+            "order": [[2, "desc"]],
+            "columns": [
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "5%" },
+                { "width": "60%" },
+              ]
+        }).columns.adjust().draw();
 
         // make controls
         let indidenceControl = chart.controls.append("div").attr("class","slider-wrap")

--- a/index.css
+++ b/index.css
@@ -43,21 +43,6 @@
     display: inline-block;
 }
 
-.axis path {
-    fill:none;
-    stroke:none;
-}
-
-.axis line {
-    fill: none;
-    stroke: #999;
-    shape-rendering: crispEdges;
-}
-
-.axis {
-    font-size:10px;
-}
-
 .slider-wrap{
 width: 300px;
 padding-right:2em;
@@ -68,6 +53,27 @@ display:inline-block;
     font-weight:1000;
 }
 
-table.dataTable thead th, table.dataTable thead td {
-    padding-bottom: 0px !important;
+table.dataTable thead th.axis{
+    padding-bottom: 0px;
+    vertical-align:bottom;
+}
+
+table.dataTable thead .axis svg {
+    font-size:10
+}
+
+table.dataTable thead .axis path {
+    fill:none;
+    stroke:none;
+}
+
+table.dataTable thead .axis line {
+    fill: none;
+    stroke: #999;
+    shape-rendering: crispEdges;
+}
+
+/* Match padding for header */
+table.dataTable tbody td.plot{
+    padding:10px 18px
 }

--- a/index.css
+++ b/index.css
@@ -67,3 +67,7 @@ display:inline-block;
 .label{
     font-weight:1000;
 }
+
+table.dataTable thead th, table.dataTable thead td {
+    padding-bottom: 0px !important;
+}


### PR DESCRIPTION
Contingent on PR #10; by setting the two plot column widths to static numbers (120, and 300 respectively) we can leverage those numbers for the axes:

- Removed the ranges since we don't need those here
- Added in axes and removed padding so the tick marks line up with the horizontal line

TODO:
- I wasn't sure how to look into the values/make sure they're plotting correctly but it does seem to match up! That said I think this line is a little troublesome for both plots:

```
var groupAxis = d3.svg.axis().scale(groupScale).ticks(6).orient("top"); 
```

Because shouldn't this go to 1-7 for the groups and 0-5 for the diffs?
