### PR TITLE
offset triangles in diff

### DIFF
--- a/forestplot.js
+++ b/forestplot.js
@@ -132,23 +132,17 @@ function forestplot(data, element, groups, pairs){
         .attr("title",d=>"p="+d.p)
         .style("font-weight",d=>d.p<0.05 ? "bold" : null) 
         .style("color", d => d.p < 0.05 ? "black" : "#ccc") 
-        
 
         var diffPlots = chart.rows.append("td")
             .attr('class','diffplot plot')
             .append('svg')
-            .attr('height', 40)
+            .attr('height', 20 * chart.pairs.length)
             .attr('width', 300)
             .append('g')
 
         var diffPoints = diffPlots.selectAll('g').data(d=>d.pairs.filter(f=>f.or)).enter().append('g')
-        .attr("transform", function (d, i) {
-            if(i === 0) {
-              return "translate(0,0)"
-          } else {
-              return "translate(0,15)"
-          }});
-          
+        .attr("transform", function (d, i) { return `translate(0, ${i * 15})` })
+
         diffPoints.append('title').text(d=>d.label+": "+d.or+" (p="+d.p+")");
         //Append graphical rate differences.
         var triangle = d3.svg

--- a/forestplot.js
+++ b/forestplot.js
@@ -137,11 +137,18 @@ function forestplot(data, element, groups, pairs){
         var diffPlots = chart.rows.append("td")
             .attr('class','diffplot plot')
             .append('svg')
-            .attr('height', 20)
+            .attr('height', 40)
             .attr('width', 300)
             .append('g')
 
-        var diffPoints = diffPlots.selectAll('g').data(d=>d.pairs.filter(f=>f.or)).enter().append('g');
+        var diffPoints = diffPlots.selectAll('g').data(d=>d.pairs.filter(f=>f.or)).enter().append('g')
+        .attr("transform", function (d, i) {
+            if(i === 0) {
+              return "translate(0,0)"
+          } else {
+              return "translate(0,15)"
+          }});
+          
         diffPoints.append('title').text(d=>d.label+": "+d.or+" (p="+d.p+")");
         //Append graphical rate differences.
         var triangle = d3.svg
@@ -152,7 +159,7 @@ function forestplot(data, element, groups, pairs){
             .y(function (d) {
                 return d.y;
             })
-            .interpolate('linear-closed');
+            .interpolate('linear-closed')
 
         diffPoints
             .append('svg:path')


### PR DESCRIPTION
Oh man so excited about how clever this is I feel like a genius I hope you like this!

1. make the diff chart height a dynamic multiple of 20 depending on the number of pairs.

```
var diffPlots = chart.rows.append("td")
    .attr('class','diffplot plot')
    .append('svg')
    .attr('height', 20 * chart.pairs.length)
    .attr('width', 300)
    .append('g')
```

2. add a conditional transform to offset the index of the of the triangle `<g>`s by i * 15 (we can change this number if it's ugly) so that the first triangle is transform(0,0), the second transform(0, 15) and so on

```
....
.attr("transform", function (d, i) { return `translate(0, ${i * 15})` })
```