### PR TITLE
adding hover to diamonds

### DIFF
--- a/forestplot.js
+++ b/forestplot.js
@@ -385,8 +385,7 @@
             .attr('y2', 20 / 2)
             .attr('stroke-width', '1px')
             .attr('stroke', 'black')
-            .attr('opacity', '0.4')
-            .append('title');
+            .attr('opacity', '0.4');
 
         //diffPoints.append('title').text(d => d[config.group1_col]+" vs. " + ': ' + d.or + ' (p=' + d.p + ')');
 
@@ -458,15 +457,21 @@
             .attr('stroke-opacity', 0.3);
 
         diffPoints.append('title').text(function(d) {
+            console.log(d);
+            var p = +d.Pvalue < 0.01 ? '<0.01' : '' + parseFloat(d.Pvalue).toFixed(2);
             return (
                 d.comp +
-                ' p: ' +
-                parseInt(d.Pvalue).toFixed(2) +
-                ', CI: [' +
-                parseInt(d.CI_Lower).toFixed(2) +
+                ' - ' +
+                d.Test +
+                ': ' +
+                parseFloat(d.Res).toFixed(2) +
+                ' [' +
+                parseFloat(d.CI_Lower).toFixed(2) +
                 ', ' +
-                parseInt(d.CI_Upper).toFixed(2) +
-                ']'
+                parseFloat(d.CI_Upper).toFixed(2) +
+                '], p: ' +
+                p +
+                ','
             );
         });
     }

--- a/forestplot.js
+++ b/forestplot.js
@@ -460,9 +460,9 @@
         diffPoints.append('title').text(function(d) {
             return (
                 d.comp +
-                ': p ' +
+                ' p: ' +
                 parseInt(d.Pvalue).toFixed(2) +
-                ', CI [' +
+                ', CI: [' +
                 parseInt(d.CI_Lower).toFixed(2) +
                 ', ' +
                 parseInt(d.CI_Upper).toFixed(2) +

--- a/forestplot.js
+++ b/forestplot.js
@@ -366,9 +366,11 @@
             })
             .enter()
             .append('g')
+            .attr('class', 'diffg')
             .attr('transform', function(d, i) {
                 return 'translate(0, ' + i * 15 + ')';
-            });
+            })
+            .attr('cursor', 'help');
 
         diffPoints
             .append('line')
@@ -383,7 +385,8 @@
             .attr('y2', 20 / 2)
             .attr('stroke-width', '1px')
             .attr('stroke', 'black')
-            .attr('opacity', '0.4');
+            .attr('opacity', '0.4')
+            .append('title');
 
         //diffPoints.append('title').text(d => d[config.group1_col]+" vs. " + ': ' + d.or + ' (p=' + d.p + ')');
 
@@ -396,7 +399,7 @@
             .y(function(d) {
                 return d.y;
             })
-            .interpolate('linear-closed')
+            .interpolate('linear-closed');
 
         diffPoints
             .append('svg:path')
@@ -453,6 +456,19 @@
                 return chart.colorScale(d[config.group2_col]);
             })
             .attr('stroke-opacity', 0.3);
+
+        diffPoints.append('title').text(function(d) {
+            return (
+                d.comp +
+                ': p ' +
+                parseInt(d.Pvalue).toFixed(2) +
+                ', CI [' +
+                parseInt(d.CI_Lower).toFixed(2) +
+                ', ' +
+                parseInt(d.CI_Upper).toFixed(2) +
+                ']'
+            );
+        });
     }
 
     function makeHeader(testData) {

--- a/src/draw/makeBody.js
+++ b/src/draw/makeBody.js
@@ -115,8 +115,7 @@ export default function makeBody(testData) {
         .attr('y2', 20 / 2)
         .attr('stroke-width', '1px')
         .attr('stroke', 'black')
-        .attr('opacity', '0.4')
-        .append('title');
+        .attr('opacity', '0.4');
 
     //diffPoints.append('title').text(d => d[config.group1_col]+" vs. " + ': ' + d.or + ' (p=' + d.p + ')');
 
@@ -173,12 +172,10 @@ export default function makeBody(testData) {
         .attr('stroke', d => chart.colorScale(d[config.group2_col]))
         .attr('stroke-opacity', 0.3);
 
-    diffPoints
-        .append('title')
-        .text(
-            d =>
-                `${d.comp} p: ${parseInt(d.Pvalue).toFixed(2)}, CI: [${parseInt(d.CI_Lower).toFixed(
-                    2
-                )}, ${parseInt(d.CI_Upper).toFixed(2)}]`
-        );
+    diffPoints.append('title').text(function(d) {
+        let p = +d.Pvalue < 0.01 ? '<0.01' : '' + parseFloat(d.Pvalue).toFixed(2);
+        return `${
+            d.comp
+        } - ${d.Test}: ${parseFloat(d.Res).toFixed(2)} [${parseFloat(d.CI_Lower).toFixed(2)}, ${parseFloat(d.CI_Upper).toFixed(2)}], p: ${p}`;
+    });
 }

--- a/src/draw/makeBody.js
+++ b/src/draw/makeBody.js
@@ -100,9 +100,11 @@ export default function makeBody(testData) {
         .data(d => d.values.comparison.filter(f => f.result_text != '-'))
         .enter()
         .append('g')
+        .attr('class', 'diffg')
         .attr('transform', function(d, i) {
             return `translate(0, ${i * 15})`;
-        });
+        })
+        .attr('cursor', 'help');
 
     diffPoints
         .append('line')
@@ -113,7 +115,8 @@ export default function makeBody(testData) {
         .attr('y2', 20 / 2)
         .attr('stroke-width', '1px')
         .attr('stroke', 'black')
-        .attr('opacity', '0.4');
+        .attr('opacity', '0.4')
+        .append('title');
 
     //diffPoints.append('title').text(d => d[config.group1_col]+" vs. " + ': ' + d.or + ' (p=' + d.p + ')');
 
@@ -169,4 +172,13 @@ export default function makeBody(testData) {
         .attr('fill', d => chart.colorScale(d[config.group2_col]))
         .attr('stroke', d => chart.colorScale(d[config.group2_col]))
         .attr('stroke-opacity', 0.3);
+
+    diffPoints
+        .append('title')
+        .text(
+            d =>
+                `${d.comp}: p: ${parseInt(d.Pvalue).toFixed(2)}, CI: [${parseInt(d.CI_Lower).toFixed(
+                    2
+                )}, ${parseInt(d.CI_Upper).toFixed(2)}]`
+        );
 }

--- a/src/draw/makeBody.js
+++ b/src/draw/makeBody.js
@@ -177,7 +177,7 @@ export default function makeBody(testData) {
         .append('title')
         .text(
             d =>
-                `${d.comp}: p: ${parseInt(d.Pvalue).toFixed(2)}, CI: [${parseInt(d.CI_Lower).toFixed(
+                `${d.comp} p: ${parseInt(d.Pvalue).toFixed(2)}, CI: [${parseInt(d.CI_Lower).toFixed(
                     2
                 )}, ${parseInt(d.CI_Upper).toFixed(2)}]`
         );


### PR DESCRIPTION
# Changelog 

- Added help cursor to diamonds as well as text to each diamond's parent `g` [took a picture on my phone because screeen captures don't capture hover text 😆 ] hopefully using the right values here!


![IMG_2112](https://user-images.githubusercontent.com/6053906/105618703-2bbe3100-5d9f-11eb-9da5-139a725f1154.jpeg)

I'm all ears for a more elegant way than:

```
    diffPoints
        .append('title')
        .text(
            d =>
                `${d.comp} p: ${parseInt(d.Pvalue).toFixed(2)}, CI: [${parseInt(d.CI_Lower).toFixed(
                    2
                )}, ${parseInt(d.CI_Upper).toFixed(2)}]`
        );
```

This should eventually close #16