### PR TITLE
multiply tick scale by 100

### DIFF
--- a/forestplot.js
+++ b/forestplot.js
@@ -396,7 +396,7 @@
             .y(function(d) {
                 return d.y;
             })
-            .interpolate('linear-closed')
+            .interpolate('linear-closed');
 
         diffPoints
             .append('svg:path')
@@ -490,7 +490,9 @@
             .axis()
             .scale(chart.rateScale)
             .ticks(3)
-            //.format('0.1%')
+            .tickFormat(function(d) {
+                return d * 100;
+            })
             .orient('top');
 
         table.head2

--- a/src/draw/makeHeader.js
+++ b/src/draw/makeHeader.js
@@ -31,7 +31,7 @@ export default function makeHeader(testData) {
         .axis()
         .scale(chart.rateScale)
         .ticks(3)
-        //.format('0.1%')
+        .tickFormat(d => d * 100)
         .orient('top');
 
     table.head2


### PR DESCRIPTION
From my understanding the scale itself is correct (on hover the points show the correct number, but we just needed to multiply the values seen in the axis by 100. I did this by including the line:

```
    var rateAxis = d3.svg
        .axis()
        .scale(chart.rateScale)
        .ticks(3)
        .tickFormat(d => d * 100) // multiply ticks by 100
        .orient('top');
```

Let me know if this was what you were envisioning

This should close #21 